### PR TITLE
More precise bower dependency version on angular

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -28,7 +28,7 @@
     "sinon": "~1.10.2"
   },
   "dependencies": {
-    "angular": "~1.2.18",
-    "angular-mocks": "~1.2.18"
+    "angular": "1.2.18",
+    "angular-mocks": "1.2.18"
   }
 }


### PR DESCRIPTION
Because we would otherwise end up with version resolution prompt when we do bower install from its depending components.
