### PR TITLE
[chore] Fix params save/load and remove angular annotations

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "widget-settings-ui-core",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "homepage": "https://github.com/Rise-Vision/widget-settings-ui-core",
   "authors": [
     "Xiyang Chen <settinghead@gmail.com>"
@@ -29,6 +29,8 @@
   },
   "dependencies": {
     "angular": "1.2.18",
-    "angular-mocks": "1.2.18"
+    "angular-mocks": "1.2.18",
+    "angular-translate": "~2.2.0",
+    "angular-translate-loader-static-files": "~2.2.0"
   }
 }

--- a/dist/widget-settings-ui-core.js
+++ b/dist/widget-settings-ui-core.js
@@ -97,6 +97,8 @@ angular.module('risevision.widget.common')
       var deferred = $q.defer();
       var alerts = [];
 
+      settings = processSettings(settings);
+
       if (validator) {
         alerts = validator(settings);
       }
@@ -122,6 +124,16 @@ angular.module('risevision.widget.common')
 
       return deferred.promise;
     };
+
+    function processSettings(settings) {
+      var newSettings = angular.copy(settings);
+
+      delete newSettings.params.id;
+      delete newSettings.params.rsW;
+      delete newSettings.params.rsH;
+
+      return newSettings;
+    }
 
   }])
 
@@ -170,7 +182,14 @@ angular.module('risevision.widget.common')
       var str = [];
       for(var p in params) {
         if (params.hasOwnProperty(p)) {
-          str.push('up_' + encodeURIComponent(p) + '=' + encodeURIComponent(params[p]));
+          var value;
+          if (typeof params[p] === 'object') {
+            value = JSON.stringify(params[p]);
+          }
+          else {
+            value = params[p];
+          }
+          str.push('up_' + encodeURIComponent(p) + '=' + encodeURIComponent(value));
         }
       }
       return '?' + str.join('&');
@@ -195,9 +214,14 @@ angular.module('risevision.widget.common')
       for (var i = 0; i < vars.length; i++) {
         var pair = vars[i].split('=');
         var name = stripPrefix(decodeURIComponent(pair[0]));
+        //save settings only if it has up_ prefix. Ignore otherwise
         if (name) {
-          //save settings only if it has up_ prefix. Ignore otherwise
-          result[name] = decodeURIComponent(pair[1]);
+          try {
+            result[name] = JSON.parse(decodeURIComponent(pair[1]));
+          }
+          catch (e) {
+            result[name] = decodeURIComponent(pair[1]);
+          }
         }
       }
       return result;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "widget-settings-ui-core",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Common components shared across Rise Vision widget settings UI",
   "main": "gulpfile.js",
   "directories": {

--- a/src/js/svc-settings.js
+++ b/src/js/svc-settings.js
@@ -6,6 +6,8 @@ angular.module('risevision.widget.common')
       var deferred = $q.defer();
       var alerts = [];
 
+      settings = processSettings(settings);
+
       if (validator) {
         alerts = validator(settings);
       }
@@ -31,6 +33,16 @@ angular.module('risevision.widget.common')
 
       return deferred.promise;
     };
+
+    function processSettings(settings) {
+      var newSettings = angular.copy(settings);
+
+      delete newSettings.params.id;
+      delete newSettings.params.rsW;
+      delete newSettings.params.rsH;
+
+      return newSettings;
+    }
 
   }])
 
@@ -79,7 +91,14 @@ angular.module('risevision.widget.common')
       var str = [];
       for(var p in params) {
         if (params.hasOwnProperty(p)) {
-          str.push('up_' + encodeURIComponent(p) + '=' + encodeURIComponent(params[p]));
+          var value;
+          if (typeof params[p] === 'object') {
+            value = JSON.stringify(params[p]);
+          }
+          else {
+            value = params[p];
+          }
+          str.push('up_' + encodeURIComponent(p) + '=' + encodeURIComponent(value));
         }
       }
       return '?' + str.join('&');
@@ -104,9 +123,14 @@ angular.module('risevision.widget.common')
       for (var i = 0; i < vars.length; i++) {
         var pair = vars[i].split('=');
         var name = stripPrefix(decodeURIComponent(pair[0]));
+        //save settings only if it has up_ prefix. Ignore otherwise
         if (name) {
-          //save settings only if it has up_ prefix. Ignore otherwise
-          result[name] = decodeURIComponent(pair[1]);
+          try {
+            result[name] = JSON.parse(decodeURIComponent(pair[1]));
+          }
+          catch (e) {
+            result[name] = decodeURIComponent(pair[1]);
+          }
         }
       }
       return result;


### PR DESCRIPTION
Correctly handle objects saved via settings.params
- JSON Stringify and Parse if a param is an object
  Copy settings variable to remove angular annotations
- Using ng-repeat adds $$hashkey to lists
- angular.copy removes the extra parameter
  Removing id, rsW and rsH params on save
  Add bower dependencies for angular-translate
  Version bump
