### PR TITLE
Revising visualization service to use unique module name and add file to build

### DIFF
--- a/dist/widget-settings-ui-core.js
+++ b/dist/widget-settings-ui-core.js
@@ -254,3 +254,35 @@ angular.module('risevision.widget.common')
   }])
 
   .value('defaultSettings', {});
+
+(function (angular) {
+  'use strict';
+
+  angular.module('risevision.widget.common.visualization')
+    .factory('visualizationApi', ['$q', '$window', function ($q, $window) {
+      var deferred = $q.defer();
+      var promise;
+
+      var factory = {
+        get: function () {
+          if (!promise) {
+            promise = deferred.promise;
+            if (!$window.google.visualization) {
+              $window.google.setOnLoadCallback(function () {
+                deferred.resolve($window.google.visualization);
+              });
+            }
+            else {
+              deferred.resolve($window.google.visualization);
+            }
+          }
+          return promise;
+        }
+      };
+      return factory;
+
+    }]);
+
+})(angular);
+
+

--- a/src/js/svc-visualization-api.js
+++ b/src/js/svc-visualization-api.js
@@ -1,8 +1,8 @@
 (function (angular) {
-  "use strict";
+  'use strict';
 
-  angular.module('risevision.widget.common')
-    .factory("visualizationApi", ["$q", "$window", function ($q, $window) {
+  angular.module('risevision.widget.common.visualization')
+    .factory('visualizationApi', ['$q', '$window', function ($q, $window) {
       var deferred = $q.defer();
       var promise;
 


### PR DESCRIPTION
- svc-visualization-api updated with single quotes to appease jshint and also adding visualization to the module name
- ran gulp build and now included in built file
