### PR TITLE
Removing dependency on angular-translate

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "widget-settings-ui-core",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "homepage": "https://github.com/Rise-Vision/widget-settings-ui-core",
   "authors": [
     "Xiyang Chen <settinghead@gmail.com>"
@@ -29,8 +29,6 @@
   },
   "dependencies": {
     "angular": "1.2.18",
-    "angular-mocks": "1.2.18",
-    "angular-translate": "~2.2.0",
-    "angular-translate-loader-static-files": "~2.2.0"
+    "angular-mocks": "1.2.18"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "widget-settings-ui-core",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Common components shared across Rise Vision widget settings UI",
   "main": "gulpfile.js",
   "directories": {


### PR DESCRIPTION
- Removing `angular-translate` and `angular-translate-loader-static-files` dependencies from bower as they aren't used and are causing conflicts in other repos, particularly widgets
- version bump