### PR TITLE
Return loaded google fonts asynchronously

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,3 +1,4 @@
 {
-  "directory" : "./components"
+  "directory" : "./components",
+  "strict-ssl": false
 }

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "widget-settings-ui-core",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "homepage": "https://github.com/Rise-Vision/widget-settings-ui-core",
   "authors": [
     "Xiyang Chen <settinghead@gmail.com>"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "jshint-stylish": "^2.1.0",
     "phantomjs": "^1.9.16",
     "run-sequence": "^0.3.2",
-    "widget-tester": "git://github.com/Rise-Vision/widget-tester.git#1.5.0"
+    "widget-tester": "git+https://github.com/Rise-Vision/widget-tester.git#v1.13.0"
   },
   "license": "GPLv3",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "widget-settings-ui-core",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "description": "Common components shared across Rise Vision widget settings UI",
   "main": "gulpfile.js",
   "directories": {

--- a/src/js/svc-google-fonts.js
+++ b/src/js/svc-google-fonts.js
@@ -1,5 +1,5 @@
 angular.module("risevision.widget.common")
-  .factory("googleFontLoader", ["$http", "angularLoad", function ($http, angularLoad) {
+  .factory("googleFontLoader", ["$http", "$q", "angularLoad", function ($http, $q, angularLoad) {
 
     var factory = {},
       allFonts = [];
@@ -48,22 +48,19 @@ angular.module("risevision.widget.common")
 
     /* Load the Google fonts. */
     function loadFonts() {
-      var family = "",
-        fonts = "",
-        url = "",
+      var fonts = "",
         urls = [],
-        spaces = false,
-        fallback = ",sans-serif;",
-        fontBaseUrl = "//fonts.googleapis.com/css?family=",
-        exclude = ["Buda", "Coda Caption", "Open Sans Condensed", "UnifrakturCook", "Molle"];
+        promises = [];
 
-      for (var i = 0; i < allFonts.length; i++) {
-        family = allFonts[i];
+      angular.forEach(allFonts, function(family){
+        var deferred  = $q.defer();
 
-        if (exclude.indexOf(family) === -1) {
-          url = fontBaseUrl + family;
+        var fontBaseUrl = "//fonts.googleapis.com/css?family=";
+        var url = fontBaseUrl + family;
+        var spaces = false;
+        var fallback = ",sans-serif;";
 
-          angularLoad.loadCSS(url);
+        angularLoad.loadCSS(url).then(function(){
           urls.push(url);
 
           // check for spaces in family name
@@ -78,10 +75,17 @@ angular.module("risevision.widget.common")
           else {
             fonts += family + "=" + family + fallback;
           }
-        }
-      }
 
-      return { fonts: fonts, urls: urls };
+          deferred.resolve({ fonts: fonts, urls: urls });
+        })
+        .catch(function() {
+          deferred.resolve({ fonts: fonts, urls: urls });
+        });
+
+        promises.push(deferred.promise);
+      });
+
+      return $q.all(promises);
     }
 
     return factory;


### PR DESCRIPTION
## Description
Modify the `googleFontLoader` factory to return `loadFonts()` asynchronously (via promise) by leveraging the promise returned from `angularLoad.loadCSS()` when the CSS file has loaded and using `$q.all()` to ensure `loadFonts()` doesn't return until all files are loaded. 

## Motivation and Context
Fixing issue https://github.com/Rise-Vision/rise-vision-apps/issues/4268

## How Has This Been Tested?
Locally and staged version of widget using these changes via commit hash, see PR https://github.com/Rise-Vision/widget-text/pull/169

https://apps.risevision.com/editor/workspace/b24a5977-cf85-427e-81b5-26af2dd6045e?cid=7fa5ee92-7deb-450b-a8d5-e5ed648c575f

Note, it is expected to see a few google fonts fail to load in the dev console. They have failed for a long time. It was cleaner in these changes to avoid an `exclusion` list and instead just let them fail. 

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No
